### PR TITLE
Detect secureboot lockdown and offer instructions on bypassing it

### DIFF
--- a/napper.py
+++ b/napper.py
@@ -137,7 +137,7 @@ def check_and_run_vuln_testing_module():
         return 0
 
     try:
-        subprocess.call('insmod napper-driver/napper.ko', shell=True)
+        subprocess.check_call('insmod napper-driver/napper.ko', shell=True)
         color_print("Starting.", SUCCESS)
     except:
         color_print("Fail.", FAIL)

--- a/napper.py
+++ b/napper.py
@@ -141,6 +141,10 @@ def check_and_run_vuln_testing_module():
         color_print("Starting.", SUCCESS)
     except:
         color_print("Fail.", FAIL)
+        print 'You might need to disable lockdown mode with'
+        print ''
+        print '     echo 1 > /proc/sys/kernel/sysrq'
+        print '     echo x > /proc/sysrq-trigger'
         return -1
  
     return 0


### PR DESCRIPTION
This fixes bug #1 at least on Lenovo X270.